### PR TITLE
Fix a boolean logic error

### DIFF
--- a/src/nemesis-proto_dns.c
+++ b/src/nemesis-proto_dns.c
@@ -118,7 +118,7 @@ int builddns(ETHERhdr *eth, IPhdr *ip, TCPhdr *tcp, UDPhdr *udp, DNShdr *dns,
 				       nemesis_lookup_linktype(l->link_type));
 			} else {
 				printf("Wrote %d byte DNS (%s) packet\n",
-				       n, ((dns_state == 1) ? "UDP" : "TCP"));
+				       n, ((dns_state == 0) ? "UDP" : "TCP"));
 			}
 		}
 	}


### PR DESCRIPTION
A bug exists that would print the wrong Layer 4 protocol being used in DNS packets.
builddns() should print "UDP" when dns_state is zero and "TCP" otherwise.

